### PR TITLE
Fix redirecting output on mono with osx

### DIFF
--- a/PacManDuel/Models/Player.cs
+++ b/PacManDuel/Models/Player.cs
@@ -51,7 +51,8 @@ namespace PacManDuel.Models
             System.Diagnostics.DataReceivedEventHandler h = (sender, args) => {
                 using (System.IO.StreamWriter file = new System.IO.StreamWriter(_workingPath + System.IO.Path.DirectorySeparatorChar + "botlogs_capture.txt", true))
                 {
-                    file.WriteLine(args.Data);
+                    if (!String.IsNullOrEmpty(args.Data)) 
+                        file.WriteLine(args.Data);
                 }
             };
             p.OutputDataReceived  += h;


### PR DESCRIPTION
The botlogs redirection did not work correctly on osx with mono. This change makes use of the built in functionality in the Process StartInfo for redirection of stdout and stderr.

Tested on osx with mono.

(Resubmission with cleaner commit history)
