### PR TITLE
Add a silent option

### DIFF
--- a/PacManDuel/Exceptions/UnreadableMazeException.cs
+++ b/PacManDuel/Exceptions/UnreadableMazeException.cs
@@ -8,13 +8,13 @@ namespace PacManDuel.Exceptions
         public UnreadableMazeException(string message) 
             : base(message)
         {
-            Console.WriteLine(message);
+            Console.Error.WriteLine(message);
         }
 
         public UnreadableMazeException(string message, Exception inner)
             : base(message, inner)
         {
-            Console.WriteLine(inner.Message);
+            Console.Error.WriteLine(inner.Message);
         }
 
     }

--- a/PacManDuel/Models/Game.cs
+++ b/PacManDuel/Models/Game.cs
@@ -62,12 +62,19 @@ namespace PacManDuel.Models
                     _maze.WriteMaze(gamePlayDirectoryPath + System.IO.Path.DirectorySeparatorChar + Properties.Settings.Default.SettingGamePlayFile);
                     CreateIterationStateFile(folderPath);
                     _iteration++;
-                    foreach (var player in _playerPool.GetPlayers())
+                    if (PacManDuel.Program.silent) 
                     {
-                        Console.Write(player.GetSymbol() + "," + player.GetPlayerName() + ": " + player.GetScore() + "  ");
+                        Console.Error.Write(".");
                     }
-                    Console.WriteLine();
-                    _maze.Print();
+                    else
+                    {
+                        foreach (var player in _playerPool.GetPlayers())
+                        {
+                            Console.Write(player.GetSymbol() + "," + player.GetPlayerName() + ": " + player.GetScore() + "  ");
+                        }
+                        Console.WriteLine();
+                        Console.WriteLine(_maze.ToFlatFormatString());
+                    }
                 }
                 else gameOutcome = ProcessIllegalMove(logFile, gameOutcome, ref winner);
             }
@@ -77,6 +84,11 @@ namespace PacManDuel.Models
             var replayMatchOutcome = new StreamWriter(folderPath + System.IO.Path.DirectorySeparatorChar + "replay" + System.IO.Path.DirectorySeparatorChar + "matchinfo.out");
             CreateMatchInfo(gameOutcome, winner, replayMatchOutcome);
             replayMatchOutcome.Close();
+            
+            if (PacManDuel.Program.silent) 
+            {
+                Console.Error.WriteLine();
+            }
 
             return new GameResult()
             {

--- a/PacManDuel/Models/Maze.cs
+++ b/PacManDuel/Models/Maze.cs
@@ -101,11 +101,6 @@ namespace PacManDuel.Models
             }
         }
 
-        public void Print()
-        {
-            Console.Out.WriteLine(ToFlatFormatString());
-        }
-
         public Point FindCoordinateOf(char symbol)
         {
             for (var x = 0; x < Properties.Settings.Default.MazeHeight; x++)

--- a/PacManDuel/Models/Player.cs
+++ b/PacManDuel/Models/Player.cs
@@ -50,7 +50,7 @@ namespace PacManDuel.Models
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                Console.Error.WriteLine(ex.ToString());
             }
             var attemptFetchingMaze = true;
             while (attemptFetchingMaze)
@@ -66,7 +66,7 @@ namespace PacManDuel.Models
                     }
                     catch (UnreadableMazeException e)
                     {
-                        Console.WriteLine(e.ToString());
+                        Console.Error.WriteLine(e.ToString());
                         logFile.WriteLine("[GAME] : Unreadable maze from player " + _playerName);
                     }
                 }


### PR DESCRIPTION
This pull request contains a silent option to the testharness. It allows for bots to be run without printing all the output to the console. The only output is dots to stderr as each round progresses, and the final result (two values) to stdout.

The main benefit of this is that it allows for running the testharness from a script to do tests and record these tests by capturing stdout.

(Tested on osx with mono)
