### PR TITLE
Replace file-exists-polling loop with Process.WaitForExit()

### DIFF
--- a/PacManDuel/Models/Player.cs
+++ b/PacManDuel/Models/Player.cs
@@ -58,7 +58,7 @@ namespace PacManDuel.Models
             p.Start();
             p.BeginOutputReadLine();
             p.BeginErrorReadLine();
-			bool didExit = p.WaitForExit(Properties.Settings.Default.SettingBotOutputTimeoutSeconds * 1000);
+            bool didExit = p.WaitForExit(Properties.Settings.Default.SettingBotOutputTimeoutSeconds * 1000);
             if (!didExit)
                 p.Kill();
 


### PR DESCRIPTION
Previously, whenever a bot's executable was invoked, the test harness waited for the output maze-file to be created inside a loop. This approach exhibits two problems:
- When the test harness tries to read the file, it is possible that the bot executable is still running and still busy writing to the file. This can cause access to the file being denied by the OS, or the test harness could read an incomplete (invalid) version of the file. See http://phpbb-entelect100k.rhcloud.com/viewtopic.php?f=6&t=56
- Again, when the test harness tries to read the file, it is possible that the bot executable is still running. It might have finished writing out the maze file, but it might still be busy performing some finalization, such as writing out temporary files prior to the next execution. In the old version, the bot executable is killed at this stage, interrupting this process even if the bot is still within its time limit.

With this change we are waiting for the process to complete or until 4 seconds had elapsed, before we kill the process (if it's still running) and try to read the file. If the file is not yet ready, or if the process is still busy performing finalizations, it means that the bot has exceeded its time-limit, and hence it is okay to terminate the process and accept the file as-is.
