### PR TITLE
Avoid file-in-use-by-another-process IO exception

### DIFF
--- a/PacManDuel/Models/Player.cs
+++ b/PacManDuel/Models/Player.cs
@@ -47,10 +47,12 @@ namespace PacManDuel.Models
             };
 
             System.Diagnostics.DataReceivedEventHandler h = (sender, args) => {
-                using (System.IO.StreamWriter file = new System.IO.StreamWriter(_workingPath + System.IO.Path.DirectorySeparatorChar + "botlogs_capture.txt", true))
+                if (!String.IsNullOrEmpty(args.Data)) 
                 {
-                    if (!String.IsNullOrEmpty(args.Data)) 
+                    using (System.IO.StreamWriter file = new System.IO.StreamWriter(_workingPath + System.IO.Path.DirectorySeparatorChar + "botlogs_capture.txt", true))
+                    {
                         file.WriteLine(args.Data);
+                    }
                 }
             };
             p.OutputDataReceived  += h;


### PR DESCRIPTION
The data-received event on the Process-object is sometimes called with a null for the Data-member, but evidently on a separate thread. On Windows this sometimes causes the file to be in use when the "main" ? thread tries to write to the file with actual data.

First check to see if there is data to write before accessing the file.

See http://phpbb-entelect100k.rhcloud.com/viewtopic.php?f=6&t=365
